### PR TITLE
Default BIND and PORT values as environment variables in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN chown runtme:runtme /usr/local/etc/private_key.der
 
 USER runtme
 
-ENV BIND "0.0.0.0"
+ENV BIND="0.0.0.0"
 
-ENV PORT "8080"
+ENV PORT="8080"
 
 CMD ["sh", "-c", "oidc-token-test-service /usr/local/etc/private_key.der -p ${PORT} -b ${BIND}"]


### PR DESCRIPTION
This fix is able to create BIND and PORT values as ENV variables in docker environment. From this we can able to set these values dynamically during run-time in docker environment